### PR TITLE
Add tests for metric conversion utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# pyrevit-addins
+
+This repository contains various pyRevit add-ins.
+
+## Running Tests
+
+Execute the following command from the repository root to run the test suite:
+
+```bash
+python -m unittest
+```

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,0 +1,38 @@
+import sys
+import types
+import builtins
+import unittest
+
+# Provide stub for __revit__ used in the library
+builtins.__revit__ = types.SimpleNamespace(ActiveUIDocument=types.SimpleNamespace(Document=None))
+
+# Provide stub modules for Autodesk.Revit.DB to satisfy imports in the library
+Autodesk = types.ModuleType("Autodesk")
+Autodesk.Revit = types.ModuleType("Autodesk.Revit")
+Autodesk.Revit.DB = types.ModuleType("Autodesk.Revit.DB")
+sys.modules.setdefault("Autodesk", Autodesk)
+sys.modules.setdefault("Autodesk.Revit", Autodesk.Revit)
+sys.modules.setdefault("Autodesk.Revit.DB", Autodesk.Revit.DB)
+
+from lib.revit_doc_interface import meter_to_double, double_to_metric
+
+
+class TestConversions(unittest.TestCase):
+    def test_metric_to_double_and_back(self):
+        values = [0, 1, 0.123, 2.345, 5.678, 0.5678]
+        for val in values:
+            as_double = meter_to_double(val)
+            back_to_metric = double_to_metric(as_double)
+            self.assertAlmostEqual(val, back_to_metric, delta=0.002)
+
+    def test_double_to_metric_and_back(self):
+        values = [0, 3.28084, 7.5, 15.245, 1.86286]
+        for val in values:
+            as_metric = double_to_metric(val)
+            back_to_double = meter_to_double(as_metric)
+            self.assertAlmostEqual(val, back_to_double, delta=0.002)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add unit tests for `meter_to_double` and `double_to_metric`
- document how to run tests

## Testing
- `python -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_68431923699083228e8f0cc0f9dc149a